### PR TITLE
fix: Activer le scaling DPI pour un rendu cohérent sur écrans Mac Retina

### DIFF
--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -15,7 +15,8 @@
     "res://specs/ui/menu/",
     "res://specs/game/",
     "res://specs/export/",
-    "res://specs/controllers/"
+    "res://specs/controllers/",
+    "res://specs/display/"
   ],
   "prefix": "test_",
   "suffix": ".gd",

--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,8 @@ config/icon="res://icon.svg"
 
 window/size/viewport_width=1920
 window/size/viewport_height=1080
+window/stretch/mode="canvas_items"
+window/stretch/aspect="expand"
 
 [editor_plugins]
 

--- a/specs/027-mac-dpi-scaling.md
+++ b/specs/027-mac-dpi-scaling.md
@@ -1,0 +1,23 @@
+# 027 — Scaling DPI pour affichage Mac Retina
+
+## Contexte
+
+Le projet visual-builder affiche des boutons et textes trop petits sur les écrans Mac Retina (haute densité de pixels), alors que l'affichage est correct sur un écran Full HD standard. Le projet définit un viewport 1920×1080 mais n'a aucun mode de stretch configuré. Sans stretch, Godot utilise la résolution physique complète du display (ex : 2880×1800 sur Retina), ce qui fait apparaître les éléments UI à une fraction de leur taille prévue.
+
+## Fonctionnalités
+
+### F1 — Stretch mode canvas_items
+
+Le projet active le mode de stretch `canvas_items` dans `project.godot`. Ce mode maintient la résolution de design (1920×1080) comme système de coordonnées pour tous les éléments UI (Controls), puis les rend à la résolution physique native. Les éléments UI conservent ainsi une taille relative constante quel que soit le display.
+
+### F2 — Aspect ratio expand
+
+Le projet utilise le mode d'aspect `expand` pour permettre à la résolution de design de s'étendre au-delà de 16:9 lorsque le display a un ratio différent (ex : 16:10 sur MacBook). Cela évite les bandes noires autour de l'interface de l'éditeur et utilise tout l'espace disponible.
+
+## Critères d'acceptation
+
+- [ ] `project.godot` définit `window/stretch/mode="canvas_items"`
+- [ ] `project.godot` définit `window/stretch/aspect="expand"`
+- [ ] Les GraphEdit (chapter, scene, sequence) fonctionnent normalement avec le stretch activé
+- [ ] L'éditeur visuel de séquence (auto-fit, letterbox) fonctionne normalement
+- [ ] Tous les tests existants passent sans régression

--- a/specs/display/test_dpi_scaling.gd
+++ b/specs/display/test_dpi_scaling.gd
@@ -1,0 +1,23 @@
+extends GutTest
+
+# Tests pour le scaling DPI — spec 027
+
+
+func test_stretch_mode_is_canvas_items():
+	var mode = ProjectSettings.get_setting("display/window/stretch/mode")
+	assert_eq(mode, "canvas_items", "Stretch mode should be canvas_items for DPI scaling")
+
+
+func test_stretch_aspect_is_expand():
+	var aspect = ProjectSettings.get_setting("display/window/stretch/aspect")
+	assert_eq(aspect, "expand", "Stretch aspect should be expand for flexible aspect ratios")
+
+
+func test_viewport_width_is_1920():
+	var w = ProjectSettings.get_setting("display/window/size/viewport_width")
+	assert_eq(w, 1920)
+
+
+func test_viewport_height_is_1080():
+	var h = ProjectSettings.get_setting("display/window/size/viewport_height")
+	assert_eq(h, 1080)


### PR DESCRIPTION
Ajoute stretch mode canvas_items + aspect expand dans project.godot pour
que l'UI conserve une taille relative constante quelle que soit la densité
de pixels de l'écran. Corrige les boutons et textes trop petits sur Mac.

https://claude.ai/code/session_01SN6ymGKJ6dYhGjcGUbcbCQ