### PR TITLE
feat: Add Godot 4.4 headless auto-install for Claude Code remote envi…

### DIFF
--- a/.claude/commands/check-global-acceptance.md
+++ b/.claude/commands/check-global-acceptance.md
@@ -1,5 +1,13 @@
 Tu es un vérificateur qualité pour le projet Godot 4.4 "visual-builder". Ta mission est d'exécuter une série de vérifications d'acceptance globales et de produire un rapport clair.
 
+## Détection du binaire Godot
+
+Avant toute vérification, détermine le binaire Godot à utiliser :
+
+```bash
+GODOT=$(command -v godot || echo "/Applications/Godot.app/Contents/MacOS/Godot")
+```
+
 ## Vérifications à effectuer
 
 Exécute chaque vérification dans l'ordre. Pour chaque étape, indique clairement le résultat : ✅ PASS ou ❌ FAIL avec les détails.
@@ -9,7 +17,7 @@ Exécute chaque vérification dans l'ordre. Pour chaque étape, indique claireme
 Vérifie que le projet se compile sans erreur en lançant un import headless :
 
 ```bash
-timeout 60 /Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/cedric/projects/perso/visual-builder --import 2>&1
+timeout 60 $GODOT --headless --path . --import 2>&1
 ```
 
 - **PASS** : pas d'erreur fatale dans la sortie
@@ -20,7 +28,7 @@ timeout 60 /Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users
 Lance la suite de tests complète :
 
 ```bash
-timeout 120 /Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/cedric/projects/perso/visual-builder -s addons/gut/gut_cmdln.gd -glog=2 2>&1
+timeout 120 $GODOT --headless --path . -s addons/gut/gut_cmdln.gd -glog=2 2>&1
 ```
 
 Analyse la sortie et extrais :
@@ -52,7 +60,7 @@ Note : s'il n'y a aucun fichier source dans `src/`, cette vérification est cons
 Vérifie que le jeu peut démarrer et s'exécuter brièvement sans crash :
 
 ```bash
-timeout 15 /Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/cedric/projects/perso/visual-builder --quit-after 3 2>&1
+timeout 15 $GODOT --headless --path . --quit-after 3 2>&1
 ```
 
 - **PASS** : le processus se termine avec un code de sortie 0 et sans erreur fatale

--- a/.claude/commands/check-requirements-acceptance.md
+++ b/.claude/commands/check-requirements-acceptance.md
@@ -29,7 +29,8 @@ Pour **chaque** critère d'acceptation, effectue une vérification concrète :
 - Identifie les tests GUT dans `specs/test_*.gd` qui couvrent ce critère
 - Lance ces tests spécifiques :
   ```bash
-  timeout 120 /Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/cedric/projects/perso/visual-builder -s addons/gut/gut_cmdln.gd -gtest=specs/<fichier_test>.gd -glog=2 2>&1
+  GODOT=$(command -v godot || echo "/Applications/Godot.app/Contents/MacOS/Godot")
+  timeout 120 $GODOT --headless --path . -s addons/gut/gut_cmdln.gd -gtest=specs/<fichier_test>.gd -glog=2 2>&1
   ```
 - Si les tests passent → preuve que le critère est satisfait
 - Si les tests échouent → le critère est **NON SATISFAIT**

--- a/.claude/commands/implement-spec.md
+++ b/.claude/commands/implement-spec.md
@@ -68,7 +68,8 @@ Pour chaque composant du plan, applique strictement le cycle Red-Green-Refactor 
 - Ne rajoute rien de plus que ce que les tests exigent
 - Lance les tests pour vérifier qu'ils passent :
   ```bash
-  /Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/cedric/projects/perso/visual-builder -s addons/gut/gut_cmdln.gd
+  GODOT=$(command -v godot || echo "/Applications/Godot.app/Contents/MacOS/Godot")
+  $GODOT --headless --path . -s addons/gut/gut_cmdln.gd
   ```
 
 #### 1.3 REFACTOR — Nettoyer
@@ -149,12 +150,14 @@ src/
 Commande pour lancer les tests GUT en ligne de commande :
 
 ```bash
+GODOT=$(command -v godot || echo "/Applications/Godot.app/Contents/MacOS/Godot")
+
 # Tous les tests
-/Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/cedric/projects/perso/visual-builder -s addons/gut/gut_cmdln.gd
+$GODOT --headless --path . -s addons/gut/gut_cmdln.gd
 
 # Un fichier de test spécifique
-/Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/cedric/projects/perso/visual-builder -s addons/gut/gut_cmdln.gd -gtest=specs/test_story_model.gd
+$GODOT --headless --path . -s addons/gut/gut_cmdln.gd -gtest=specs/test_story_model.gd
 
 # Avec plus de verbosité
-/Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/cedric/projects/perso/visual-builder -s addons/gut/gut_cmdln.gd -glog=3
+$GODOT --headless --path . -s addons/gut/gut_cmdln.gd -glog=3
 ```

--- a/.claude/hooks/install-godot.sh
+++ b/.claude/hooks/install-godot.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+GODOT_VERSION="4.4"
+GODOT_RELEASE="4.4-stable"
+GODOT_BINARY_NAME="Godot_v${GODOT_VERSION}-stable_linux.x86_64"
+GODOT_ZIP="${GODOT_BINARY_NAME}.zip"
+GODOT_URL="https://github.com/godotengine/godot/releases/download/${GODOT_RELEASE}/${GODOT_ZIP}"
+INSTALL_PATH="/usr/local/bin/godot"
+
+# Check if Godot is already installed with correct version
+if command -v godot &> /dev/null; then
+    INSTALLED_VERSION=$(godot --version 2>/dev/null | cut -d. -f1-2)
+    if [ "$INSTALLED_VERSION" = "$GODOT_VERSION" ]; then
+        echo "Godot $GODOT_VERSION already installed."
+        exit 0
+    fi
+    echo "Godot found but wrong version ($INSTALLED_VERSION). Upgrading..."
+fi
+
+echo "Installing Godot $GODOT_VERSION headless..."
+
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# Download with retry (up to 4 attempts with exponential backoff)
+RETRY=0
+MAX_RETRIES=4
+while [ $RETRY -lt $MAX_RETRIES ]; do
+    if curl -L -o "$TEMP_DIR/$GODOT_ZIP" "$GODOT_URL" 2>/dev/null; then
+        break
+    fi
+    RETRY=$((RETRY + 1))
+    if [ $RETRY -lt $MAX_RETRIES ]; then
+        WAIT=$((2 ** RETRY))
+        echo "Download failed. Retrying in ${WAIT}s... (attempt $((RETRY + 1))/$MAX_RETRIES)"
+        sleep $WAIT
+    else
+        echo "ERROR: Failed to download Godot after $MAX_RETRIES attempts."
+        exit 1
+    fi
+done
+
+# Extract and install
+cd "$TEMP_DIR"
+unzip -o "$GODOT_ZIP" > /dev/null
+cp "$GODOT_BINARY_NAME" "$INSTALL_PATH"
+chmod +x "$INSTALL_PATH"
+
+echo "Godot $(godot --version 2>/dev/null) installed to $INSTALL_PATH"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash $CLAUDE_PROJECT_DIR/.claude/hooks/install-godot.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,33 +6,52 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Godot 4.4 project ("visual-builder") using GL Compatibility renderer (supports web/HTML5 export).
 
+## Environnement Godot
+
+Le binaire Godot est installé automatiquement via le hook SessionStart (`.claude/hooks/install-godot.sh`).
+
+- **Local (macOS)** : `/Applications/Godot.app/Contents/MacOS/Godot`
+- **Remote (Linux / Claude Code web)** : `godot` (installé dans `/usr/local/bin/godot`)
+
+Pour déterminer quel binaire utiliser :
+
+```bash
+# Détection automatique
+GODOT=$(command -v godot || echo "/Applications/Godot.app/Contents/MacOS/Godot")
+```
+
 ## Running the Project
 
 ```bash
-# Open in Godot editor
-/Applications/Godot.app/Contents/MacOS/Godot --editor --path /Users/cedric/projects/perso/visual-builder
+# Open in Godot editor (local macOS)
+/Applications/Godot.app/Contents/MacOS/Godot --editor --path .
 
 # Run the project directly
-/Applications/Godot.app/Contents/MacOS/Godot --path /Users/cedric/projects/perso/visual-builder
+$GODOT --path .
 ```
 
 ## Exécution des tests GUT
 
-GUT est configuré avec `"should_exit": true` dans `.gutconfig.json`, ce qui fait quitter Godot automatiquement après les tests. Le `gtimeout` sert uniquement de filet de sécurité.
+GUT est configuré avec `"should_exit": true` dans `.gutconfig.json`, ce qui fait quitter Godot automatiquement après les tests. Le `timeout` sert uniquement de filet de sécurité.
 
 ```bash
+# Détection du binaire Godot
+GODOT=$(command -v godot || echo "/Applications/Godot.app/Contents/MacOS/Godot")
+
 # Lancer tous les tests GUT
-gtimeout 30 /Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/cedric/projects/perso/visual-builder -s addons/gut/gut_cmdln.gd
+timeout 120 $GODOT --headless --path . -s addons/gut/gut_cmdln.gd
 
 # Lancer un fichier de test spécifique
-gtimeout 30 /Applications/Godot.app/Contents/MacOS/Godot --headless --path /Users/cedric/projects/perso/visual-builder -s addons/gut/gut_cmdln.gd -gtest=res://specs/test_example.gd
+timeout 30 $GODOT --headless --path . -s addons/gut/gut_cmdln.gd -gtest=res://specs/test_example.gd
 ```
 
 ## Project Structure
 
 - `project.godot` — Main engine configuration
-- `specs/` — Test directory (empty, framework TBD)
+- `specs/` — Test directory (GUT tests + Markdown specifications)
 - `.godot/` — Engine cache (gitignored, auto-generated)
+- `.claude/hooks/install-godot.sh` — Script d'installation automatique de Godot headless
+- `.claude/settings.json` — Configuration des hooks Claude Code (SessionStart)
 
 ## Priorities
 


### PR DESCRIPTION
…ronment

Add a SessionStart hook that automatically downloads and installs Godot 4.4 headless on Linux when a Claude Code web session starts. Update all commands and CLAUDE.md to use portable Godot detection (`command -v godot` with macOS fallback) and relative paths instead of hardcoded macOS paths.

- .claude/hooks/install-godot.sh: auto-install script with retry logic
- .claude/settings.json: SessionStart hook configuration
- CLAUDE.md: portable instructions for both local and remote
- All slash commands updated for cross-platform compatibility

https://claude.ai/code/session_01XDxmZKqiHcqk1UeHa9fUL2